### PR TITLE
Remove dynatrace functions and references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.21
+FROM postgres:12.22
 
 RUN apt-get update && apt install curl -y && apt clean
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.8
+FROM postgres:12.22
 
 RUN apt-get update && apt install curl -y && apt clean
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.3
+FROM postgres:13.21
 
 RUN apt-get update && apt install curl -y && apt clean
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.22
+FROM postgres:12.8
 
 RUN apt-get update && apt install curl -y && apt clean
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/ops/boot.sh
+++ b/ops/boot.sh
@@ -1,9 +1,2 @@
 #!/bin/bash -ex
-if [ ! -z "$DYNATRACE_TOKEN" ];then
-  curl -Ls -H "Authorization: Api-Token ${DYNATRACE_TOKEN}" 'https://nhd42358.live.dynatrace.com/api/v1/deployment/installer/agent/unix/default/latest?arch=x86&flavor=default' > installer.sh
-
-  /bin/sh installer.sh --set-app-log-content-access=true --set-infra-only=true --set-host-group=DC --set-host-name=${CLUSTER_NAME}-psql 2>&1 & 
-fi
-
 su  postgres -c "/docker-entrypoint.sh postgres -c 'max_connections=500'"
-

--- a/ops/boot.sh
+++ b/ops/boot.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -ex
-su  postgres -c "/docker-entrypoint.sh postgres -c 'max_connections=500'"
+su  postgres -c "postgres -c 'max_connections=500'"

--- a/toy.docker-compose.yml
+++ b/toy.docker-compose.yml
@@ -10,7 +10,6 @@ services:
     volumes:
       - "db:/var/lib/postgresql/data"
     environment:
-      DYNATRACE_TOKEN: ${DYNATRACE_TOKEN}
       CLUSTER_NAME: ${CLUSTER_NAME}
       # This should be a comma delimited list of databases, no spaces
       POSTGRES_MULTIPLE_DATABASES: blacklight_yul_development,yul_dc_management_development

--- a/toy.docker-compose.yml
+++ b/toy.docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     command: /bin/bash -c '/boot.sh'


### PR DESCRIPTION
# Summary
Removes dynatrace token variable and removes functions that use Dynatrace.  Also removes deprecated 'version' syntax from docker compose file and bumps psql version.

# Related Ticket
[#3100](https://github.com/yalelibrary/YUL-DC/issues/3100)

# Notes

<details>

Error with old version of psql during build so bumped to more recent version.
<img width="1959" height="1137" alt="image" src="https://github.com/user-attachments/assets/235cc107-1635-4c4f-8cc8-fb8685d185ec" />


</details>